### PR TITLE
Refactoring `statechannel` syncing

### DIFF
--- a/apps/indexer-coordinator/.eslintrc.js
+++ b/apps/indexer-coordinator/.eslintrc.js
@@ -57,7 +57,7 @@ module.exports = {
     "header/header": [2, "line", [
       {
         "pattern": " Copyright \\d{4}(-\\d{4})? SubQuery Pte Ltd authors & contributors",
-        "template": " Copyright 2020-2022 SubQuery Pte Ltd authors & contributors"
+        "template": " Copyright 2020-2023 SubQuery Pte Ltd authors & contributors"
       },
       " SPDX-License-Identifier: Apache-2.0"
     ], 2]

--- a/apps/indexer-coordinator/src/payg/payg.service.ts
+++ b/apps/indexer-coordinator/src/payg/payg.service.ts
@@ -3,19 +3,20 @@
 
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { StateChannel } from '@subql/network-query';
-import { BigNumber } from 'ethers';
 import { MoreThan, Repository } from 'typeorm';
 
-import { AccountService } from '../core/account.service';
 import { NetworkService } from '../core/network.service';
 import { PaygEntity } from '../project/project.model';
 import { SubscriptionService } from '../subscription/subscription.service';
 import { getLogger } from '../utils/logger';
 import { PaygEvent } from '../utils/subscription';
+import { AccountService } from './../core/account.service';
 
-import { Channel, ChannelLabor, ChannelStatus } from './payg.model';
-import { PaygQueryService } from './payg.query.service';
+import { StateChannel, bytes32ToCid } from '@subql/network-clients';
+import { ZERO_ADDRESS } from 'src/utils/project';
+import { Channel, ChannelStatus } from './payg.model';
+
+export type ChannelState = StateChannel.ChannelStateStructOutput;
 
 const logger = getLogger('payg');
 
@@ -24,15 +25,73 @@ export class PaygService {
   constructor(
     @InjectRepository(Channel) private channelRepo: Repository<Channel>,
     @InjectRepository(PaygEntity) private paygRepo: Repository<PaygEntity>,
-    @InjectRepository(ChannelLabor) private laborRepo: Repository<ChannelLabor>,
     private pubSub: SubscriptionService,
     private network: NetworkService,
     private account: AccountService,
-    private paygQuery: PaygQueryService
   ) { }
 
-  channel(id: string): Promise<Channel> {
-    return this.channelRepo.findOneBy({ id });
+  async channelFromContract(id: string): Promise<ChannelState> {
+    const channel = await this.network.getSdk().stateChannel.channel(id);
+    return channel?.indexer !== ZERO_ADDRESS ? channel : undefined;
+  }
+
+  async saveChannel(
+    id: string,
+    channelState: StateChannel.ChannelStateStructOutput,
+    price: string,
+    agent: string,
+  ): Promise<Channel> {
+    const hostIndexer = await this.account.getIndexer();
+    if (channelState?.indexer !== hostIndexer) return;
+
+    const {
+      status,
+      indexer,
+      consumer,
+      total,
+      spent,
+      expiredAt,
+      terminatedAt,
+      deploymentId,
+      terminateByIndexer,
+    } = channelState;
+
+    const channelEntity = this.channelRepo.create({
+      id,
+      status,
+      indexer,
+      consumer,
+      agent,
+      price,
+      deploymentId: bytes32ToCid(deploymentId),
+      total: total.toString(),
+      spent: spent.toString(),
+      lastIndexerSign: '',
+      lastConsumerSign: '',
+      onchain: '0',
+      remote: '0',
+      expiredAt: expiredAt.toNumber(),
+      terminatedAt: terminatedAt.toNumber(),
+      terminateByIndexer,
+      lastFinal: false,
+    });
+
+    const channel = await this.channelRepo.save(channelEntity);
+    logger.debug(`Saved state channel ${id}`);
+
+    return channel;
+  }
+
+  async channel(channelId: string): Promise<Channel | undefined> {
+    const id = channelId.toLowerCase();
+    let channel = await this.channelRepo.findOneBy({ id });
+
+    if (!channel) {
+      const channelState = await this.channelFromContract(id);
+      channel = await this.saveChannel(id, channelState, '0', '');
+    }
+
+    return channel;
   }
 
   async channels(): Promise<Channel[]> {
@@ -55,12 +114,7 @@ export class PaygService {
     consumerSign: string
   ): Promise<Channel> {
     try {
-      let channel = await this.channel(id);
-      if (!channel) {
-        const stateChannel = await this.paygQuery.getStateChannel(id);
-        channel = await this.syncChannel(stateChannel);
-      }
-
+      const channel = await this.channel(id);
       if (!channel) {
         throw new Error(`channel not exist: ${id}`);
       }
@@ -184,170 +238,6 @@ export class PaygService {
     logger.debug(`Responded state channel ${id}`);
 
     return this.savePub(channel, PaygEvent.State);
-  }
-
-  async syncChannel(channel: StateChannel): Promise<Channel | undefined> {
-    if (!channel) return;
-
-    try {
-      const id = BigNumber.from(channel.id).toString();
-      const _channel = await this.channel(id);
-      if (_channel) return;
-
-      const {
-        deployment,
-        indexer,
-        consumer,
-        agent,
-        total,
-        spent,
-        price,
-        expiredAt,
-        terminatedAt,
-        terminateByIndexer,
-        isFinal,
-      } = channel;
-
-      const channelObj = {
-        id,
-        deploymentId: deployment.id,
-        indexer,
-        consumer,
-        agent,
-        spent: spent.toString(),
-        total: total.toString(),
-        price: price.toString(),
-        lastIndexerSign: '',
-        lastConsumerSign: '',
-        onchain: '0',
-        remote: '0',
-        status: ChannelStatus.OPEN,
-        expiredAt: new Date(expiredAt).valueOf() / 1000,
-        terminatedAt: new Date(terminatedAt).valueOf() / 1000,
-        terminateByIndexer,
-        lastFinal: isFinal,
-      };
-
-      const channelEntity = this.channelRepo.create(channelObj);
-      await this.channelRepo.save(channelEntity);
-      logger.debug(`Synced state channel ${id}`);
-
-      return channelEntity;
-    } catch (e) {
-      logger.error(`Failed to sync state channel ${channel.id} with error: ${e}`);
-    }
-  }
-
-  async syncOpen(
-    id: string,
-    indexer: string,
-    consumer: string,
-    agent: string,
-    total: string,
-    price: string,
-    expiredAt: number,
-    deploymentId: string
-  ) {
-    // update the channel.
-    const channel = await this.channel(id);
-    if (!channel) {
-      // check if self.
-      const myIndexer = await this.account.getIndexer();
-      if (indexer !== myIndexer) return;
-
-      const channel = this.channelRepo.create({
-        id,
-        deploymentId,
-        indexer,
-        consumer,
-        agent,
-        total,
-        price,
-        expiredAt,
-        lastIndexerSign: '',
-        lastConsumerSign: '',
-        status: ChannelStatus.OPEN,
-        spent: '0',
-        onchain: '0',
-        remote: '0',
-        terminatedAt: expiredAt,
-        terminateByIndexer: false,
-        lastFinal: false,
-      });
-
-      await this.savePub(channel, PaygEvent.Opened);
-    } else {
-      // update information (NOT CHANGE price and isFinal)
-      channel.indexer = indexer;
-      channel.consumer = consumer;
-      channel.agent = agent;
-      channel.total = total;
-      channel.expiredAt = expiredAt;
-      channel.terminatedAt = expiredAt;
-      channel.deploymentId = deploymentId;
-      channel.lastFinal = false;
-
-      await this.savePub(channel, PaygEvent.State);
-    }
-  }
-
-  async syncExtend(id: string, expiredAt: number) {
-    const channel = await this.channel(id);
-    if (!channel) return;
-
-    channel.expiredAt = expiredAt;
-    channel.terminatedAt = expiredAt;
-    await this.channelRepo.save(channel);
-  }
-
-  async syncFund(id: string, total: string) {
-    const channel = await this.channel(id);
-    if (!channel) return;
-
-    channel.total = total;
-    await this.savePub(channel, PaygEvent.State);
-  }
-
-  async syncCheckpoint(id: string, onchain: string) {
-    const channel = await this.channel(id);
-    if (!channel) return;
-
-    channel.onchain = onchain;
-    await this.channelRepo.save(channel);
-  }
-
-  async syncTerminate(id: string, onchain: string, terminatedAt: number, byIndexer: boolean) {
-    const channel = await this.channel(id);
-    if (!channel) return;
-
-    channel.onchain = onchain;
-    channel.status = ChannelStatus.TERMINATING;
-    channel.terminatedAt = terminatedAt;
-    channel.terminateByIndexer = byIndexer;
-    channel.lastFinal = true;
-
-    await this.savePub(channel, PaygEvent.State);
-  }
-
-  async syncFinalize(id: string, total: BigNumber, remain: BigNumber) {
-    const channel = await this.channel(id);
-    if (!channel) return;
-
-    channel.onchain = total.sub(remain).toString();
-    channel.status = ChannelStatus.FINALIZED;
-    channel.lastFinal = true;
-
-    await this.savePub(channel, PaygEvent.Stopped);
-  }
-
-  async syncLabor(deploymentId: string, indexer: string, total: string, createdAt: number) {
-    const labor = this.laborRepo.create({
-      deploymentId: deploymentId,
-      indexer: indexer,
-      total: total,
-      createdAt: createdAt,
-    });
-    await this.laborRepo.save(labor);
   }
 
   async savePub(channel: Channel, event: PaygEvent): Promise<Channel> {

--- a/apps/indexer-coordinator/src/payg/payg.sync.service.ts
+++ b/apps/indexer-coordinator/src/payg/payg.sync.service.ts
@@ -3,11 +3,17 @@
 
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { utils } from 'ethers';
+import { ChannelStatus, StateChannel } from '@subql/network-query';
+import { BigNumber, utils } from 'ethers';
 import { chunk } from 'lodash';
 
+import { InjectRepository } from '@nestjs/typeorm';
+import { AccountService } from 'src/core/account.service';
+import { PaygEvent } from 'src/utils/subscription';
+import { Repository } from 'typeorm';
 import { ContractService } from '../core/contract.service';
 import { getLogger } from '../utils/logger';
+import { Channel, ChannelLabor } from './payg.model';
 import { PaygQueryService } from './payg.query.service';
 import { PaygService } from './payg.service';
 
@@ -16,10 +22,13 @@ const logger = getLogger('payg');
 @Injectable()
 export class PaygSyncService implements OnApplicationBootstrap {
   constructor(
+    @InjectRepository(Channel) private channelRepo: Repository<Channel>,
+    @InjectRepository(ChannelLabor) private laborRepo: Repository<ChannelLabor>,
     private contractService: ContractService,
     private paygQueryService: PaygQueryService,
-    private paygServicee: PaygService
-  ) {}
+    private paygService: PaygService,
+    private account: AccountService,
+  ) { }
 
   onApplicationBootstrap() {
     void (() => {
@@ -34,10 +43,67 @@ export class PaygSyncService implements OnApplicationBootstrap {
       const channels = await this.paygQueryService.getStateChannels();
 
       for (const batch of chunk(channels, 10)) {
-        await Promise.all(batch.map((channel) => this.paygServicee.syncChannel(channel)));
+        await Promise.all(batch.map((channel) => this.syncChannel(channel)));
       }
     } catch (e) {
       logger.error(`Failed to sync state channels from Subquery Project: ${e}`);
+    }
+  }
+
+  async syncChannel(channel: StateChannel): Promise<void> {
+    if (!channel) return;
+
+    try {
+      const id = BigNumber.from(channel.id).toString().toLowerCase();
+      const _channel = await this.channelRepo.findOneBy({ id });
+
+      // update channel price and agent
+      if (_channel && _channel.price === '0') {
+        _channel.agent = channel.agent;
+        _channel.price = channel.price.toString();
+        await this.channelRepo.save(_channel);
+        return;
+      };
+
+      const {
+        deployment,
+        indexer,
+        consumer,
+        agent,
+        total,
+        spent,
+        price,
+        expiredAt,
+        terminatedAt,
+        terminateByIndexer,
+        isFinal,
+      } = channel;
+
+      const channelObj = {
+        id,
+        deploymentId: deployment.id,
+        indexer,
+        consumer,
+        agent,
+        spent: spent.toString(),
+        total: total.toString(),
+        price: price.toString(),
+        lastIndexerSign: '',
+        lastConsumerSign: '',
+        onchain: '0',
+        remote: '0',
+        status: ChannelStatus.OPEN,
+        expiredAt: new Date(expiredAt).valueOf() / 1000,
+        terminatedAt: new Date(terminatedAt).valueOf() / 1000,
+        terminateByIndexer,
+        lastFinal: isFinal,
+      };
+
+      const channelEntity = this.channelRepo.create(channelObj);
+      await this.channelRepo.save(channelEntity);
+      logger.debug(`Synced state channel ${id}`);
+    } catch (e) {
+      logger.error(`Failed to sync state channel ${channel.id} with error: ${e}`);
     }
   }
 
@@ -47,7 +113,10 @@ export class PaygSyncService implements OnApplicationBootstrap {
 
     stateChannel.on(
       'ChannelOpen',
-      (channelId, indexer, consumer, total, price, expiredAt, deploymentId, callback) => {
+      async (channelId, indexer, consumer, total, price, expiredAt, deploymentId, callback) => {
+        const hostIndexer = await this.account.getIndexer();
+        if (indexer !== hostIndexer) return;
+
         let agent = '';
         let user = consumer;
         try {
@@ -58,33 +127,32 @@ export class PaygSyncService implements OnApplicationBootstrap {
           logger.debug(`Channel created by user: ${consumer}`);
         }
 
-        void this.paygServicee.syncOpen(
+        void this.syncOpen(
           channelId.toString(),
-          indexer,
-          user,
           agent,
-          total.toString(),
           price.toString(),
-          expiredAt.toNumber(),
-          deploymentId
+          agent,
+          {
+
+          }
         );
       }
     );
 
     stateChannel.on('ChannelExtend', (channelId, expiredAt) => {
-      void this.paygServicee.syncExtend(channelId.toString(), expiredAt.toNumber());
+      void this.syncExtend(channelId.toString(), expiredAt.toNumber());
     });
 
     stateChannel.on('ChannelFund', (channelId, total) => {
-      void this.paygServicee.syncFund(channelId.toString(), total.toString());
+      void this.syncFund(channelId.toString(), total.toString());
     });
 
     stateChannel.on('ChannelCheckpoint', (channelId, spent) => {
-      void this.paygServicee.syncCheckpoint(channelId.toString(), spent.toString());
+      void this.syncCheckpoint(channelId.toString(), spent.toString());
     });
 
     stateChannel.on('ChannelTerminate', (channelId, spent, terminatedAt, terminateByIndexer) => {
-      void this.paygServicee.syncTerminate(
+      void this.syncTerminate(
         channelId.toString(),
         spent.toString(),
         terminatedAt.toNumber(),
@@ -93,7 +161,7 @@ export class PaygSyncService implements OnApplicationBootstrap {
     });
 
     stateChannel.on('ChannelFinalize', (channelId, total, remain) => {
-      void this.paygServicee.syncFinalize(
+      void this.syncFinalize(
         channelId.toString(),
         total,
         remain
@@ -103,7 +171,82 @@ export class PaygSyncService implements OnApplicationBootstrap {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stateChannel.on('ChannelLabor', async (deploymentId, indexer, amount) => {
       const chainLastBlock = await this.contractService.getLastBlockNumber();
-      await this.paygServicee.syncLabor(deploymentId, indexer, amount.toString(), chainLastBlock);
+      await this.syncLabor(deploymentId, indexer, amount.toString(), chainLastBlock);
     });
   }
+
+
+  /// functions called by contract event listener
+  async syncOpen(
+    id: string,
+    agent: string,
+    price: string,
+  ) {
+    const channel = await this.paygService.channel(id);
+    if (channel) return;
+
+    channel.agent = agent;
+    channel.price = price;
+    await this.paygService.savePub(channel, PaygEvent.Opened);
+  }
+
+  async syncExtend(id: string, expiredAt: number) {
+    const channel = await this.paygService.channel(id);
+    if (!channel) return;
+
+    channel.expiredAt = expiredAt;
+    channel.terminatedAt = expiredAt;
+    await this.paygService.savePub(channel, PaygEvent.State);
+  }
+
+  async syncFund(id: string, total: string) {
+    const channel = await this.paygService.channel(id);
+    if (!channel) return;
+
+    channel.total = total;
+    await this.paygService.savePub(channel, PaygEvent.State);
+  }
+
+  async syncCheckpoint(id: string, onchain: string) {
+    const channel = await this.paygService.channel(id);
+    if (!channel) return;
+
+    channel.onchain = onchain;
+    await this.paygService.savePub(channel, PaygEvent.State);
+  }
+
+  async syncTerminate(id: string, onchain: string, terminatedAt: number, byIndexer: boolean) {
+    const channel = await this.paygService.channel(id);
+    if (!channel) return;
+
+    channel.onchain = onchain;
+    channel.status = ChannelStatus.TERMINATING;
+    channel.terminatedAt = terminatedAt;
+    channel.terminateByIndexer = byIndexer;
+    channel.lastFinal = true;
+
+    await this.paygService.savePub(channel, PaygEvent.State);
+  }
+
+  async syncFinalize(id: string, total: BigNumber, remain: BigNumber) {
+    const channel = await this.paygService.channel(id);
+    if (!channel) return;
+
+    channel.onchain = total.sub(remain).toString();
+    channel.status = ChannelStatus.FINALIZED;
+    channel.lastFinal = true;
+
+    await this.paygService.savePub(channel, PaygEvent.Stopped);
+  }
+
+  async syncLabor(deploymentId: string, indexer: string, total: string, createdAt: number) {
+    const labor = this.laborRepo.create({
+      deploymentId: deploymentId,
+      indexer: indexer,
+      total: total,
+      createdAt: createdAt,
+    });
+    await this.laborRepo.save(labor);
+  }
+
 }

--- a/apps/indexer-coordinator/src/utils/project.ts
+++ b/apps/indexer-coordinator/src/utils/project.ts
@@ -84,4 +84,6 @@ export async function nodeConfigs(
   return { chainType, dockerRegistry: dockerRegistryFromChain(chainType) };
 }
 
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 export const ZERO_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';


### PR DESCRIPTION
## Changes

There are 3 sources for syncing state channel:

- A cron job to sync the channels from subquery project
- Get and save the channel from contract if it not exist in the db
- A listener function for `ChannelOpened` event

To simplify the state channel syncing:

- Split all the syncing functions out of `payg.service`
- `payg.service` only provide the functions consume externally.
- For each action in both `payg.service` and `payg.query.service`, will try to sync the channel from contract if it not exist in db.