### PR TITLE
fix: deep clone Graphql result when want to change it.

### DIFF
--- a/apps/indexer-admin/src/pages/controllers/controllersPage.tsx
+++ b/apps/indexer-admin/src/pages/controllers/controllersPage.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from 'react';
 import { useLazyQuery, useMutation } from '@apollo/client';
-import { isEmpty, isUndefined } from 'lodash';
+import { cloneDeep, isEmpty, isUndefined } from 'lodash';
 
 import IntroductionView from 'components/introductionView';
 import { PopupView } from 'components/popupView';
@@ -63,7 +63,7 @@ const controllersPage = () => {
       return address.toLowerCase() === currentController?.toLowerCase();
     };
 
-    const rawControllers = controllerData?.controllers;
+    const rawControllers = cloneDeep(controllerData?.controllers);
     const index = rawControllers.findIndex((c) => isActivedController(c.address));
     if (index !== -1) {
       const [item] = rawControllers.splice(index, 1);


### PR DESCRIPTION

Install by new `yarn.lock` will have error when change raw result response from Graphql.