### PR TITLE
Bump indexer-proxy v1.3.0

### DIFF
--- a/apps/indexer-proxy/proxy/Cargo.toml
+++ b/apps/indexer-proxy/proxy/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "subql-indexer-proxy"
-version = "1.2.6"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]
-subql-indexer-utils = { version = "1.2", path = "../utils" }
+subql-indexer-utils = { version = "1.3", path = "../utils" }
 subql-contracts = { git = "https://github.com/subquery/network-contracts", branch = "rust-v0.14.0" }
 aes-gcm = "0.10"
 axum = "0.6"

--- a/apps/indexer-proxy/utils/Cargo.toml
+++ b/apps/indexer-proxy/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subql-indexer-utils"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
until contract upgrade to support stable coin.