### PR TITLE
fix: infinity loading if current chain is not supported network & long name display

### DIFF
--- a/apps/indexer-admin/src/App.tsx
+++ b/apps/indexer-admin/src/App.tsx
@@ -77,19 +77,21 @@ const AppContents = () => {
         </div>
       );
 
-    if (loading || registedIndexerLoading) return <LoadingSpinner />;
-
     return (
       <ChainStatus>
-        <Switch>
-          <Route component={Pages.Projects} path="/projects" />
-          <Route exact component={Pages.ProjectDetail} path="/project/:id" />
-          <Route component={Pages.Account} path="/account" />
-          <Route component={Pages.ControllerManagement} path="/controller-management" />
-          <Route component={Pages.Network} path="/network" />
-          <Route component={Pages.Register} path="/register" />
-          <Route component={Pages.Login} path="/" />
-        </Switch>
+        {loading || registedIndexerLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <Switch>
+            <Route component={Pages.Projects} path="/projects" />
+            <Route exact component={Pages.ProjectDetail} path="/project/:id" />
+            <Route component={Pages.Account} path="/account" />
+            <Route component={Pages.ControllerManagement} path="/controller-management" />
+            <Route component={Pages.Network} path="/network" />
+            <Route component={Pages.Register} path="/register" />
+            <Route component={Pages.Login} path="/" />
+          </Switch>
+        )}
       </ChainStatus>
     );
   }, [loading, registedIndexerLoading, error, address]);

--- a/apps/indexer-admin/src/components/accountCard.tsx
+++ b/apps/indexer-admin/src/components/accountCard.tsx
@@ -49,7 +49,7 @@ const AccountCard: FC<Props> = ({ title, desc, buttons, name, account }) => {
           <ContentContainer>
             <Avatar address={account ?? ''} size={100} />
             <DescContainer ml={20}>
-              <Text>{name}</Text>
+              <Text className="overflowEllipsis2">{name}</Text>
               <Text mt={10}>{account}</Text>
               <Text mt={10}>{desc}</Text>
             </DescContainer>
@@ -111,4 +111,5 @@ const DescContainer = styled.div<{ ml?: number }>`
 const GroupButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
 `;

--- a/apps/indexer-admin/src/hooks/indexerHook.ts
+++ b/apps/indexer-admin/src/hooks/indexerHook.ts
@@ -30,11 +30,9 @@ export const useIsRegistedIndexer = (): {
   const [loading, setLoading] = useState(true);
   const getIsIndexer = useCallback(async () => {
     if (!account || !sdk) return;
-
     try {
       setLoading(true);
       const status = await sdk.indexerRegistry.isIndexer(account);
-
       updateIsRegisterIndexer(status);
     } catch (e) {
       notificationMsg({

--- a/apps/indexer-admin/src/pages/network/networkPage.tsx
+++ b/apps/indexer-admin/src/pages/network/networkPage.tsx
@@ -40,7 +40,7 @@ const NetworkPage = () => {
       <LeftContainer>
         <Avatar address={account ?? ''} size={100} />
         <ContentContainer>
-          <Text fw="600" size={30}>
+          <Text className="overflowEllipsis2" fw="600" size={30}>
             {metadata?.name}
           </Text>
           <Text fw="400" size={15}>


### PR DESCRIPTION

Tested cases:

- [x] User enter the pages with supported network.
   - [x] At any pages, work as normal.
- [x] User enter the pages with unsupported network.
   - [x] At any pages, tips to switch network and then continue the load action.
 
- [x] Node Operator name display on account page/network page.