### PR TITLE
fix reids compile warning

### DIFF
--- a/apps/indexer-proxy/proxy/src/websocket.rs
+++ b/apps/indexer-proxy/proxy/src/websocket.rs
@@ -283,7 +283,7 @@ impl WebSocketConnection {
         let cache_key = format!("{}-ws", keyname);
 
         let mut conn = redis();
-        redis::cmd("SETEX")
+        let _: () = redis::cmd("SETEX")
             .arg(&cache_key)
             .arg(600) // 10min
             .arg(value)
@@ -307,7 +307,7 @@ impl WebSocketConnection {
             .query_async(&mut conn)
             .await
             .map_err(|_| Error::WebSocket(1306))?;
-        let _ = redis::cmd("DEL")
+        let _: () = redis::cmd("DEL")
             .arg(&cache_key)
             .query_async(&mut conn)
             .await


### PR DESCRIPTION
fix warning:
```
warning: this function depends on never type fallback being `()`
   --> apps/indexer-proxy/proxy/src/websocket.rs:259:5
    |
259 | /     async fn before_query_payg_check(
260 | |         auth: String,
261 | |         _project: Project,
262 | |         unit_times: u64,
263 | |         _unit_overflow: u64,
264 | |     ) -> Result<(Option<String>, U256, U256, U256), Error> {
    | |__________________________________________________________^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
note: in edition 2024, the requirement `!: FromRedisValue` will fail
   --> apps/indexer-proxy/proxy/src/websocket.rs:290:14
    |
290 |             .query_async(&mut conn)
    |              ^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default

warning: this function depends on never type fallback being `()`
   --> apps/indexer-proxy/proxy/src/websocket.rs:301:5
    |
301 |     async fn fetch_state(keyname: &str) -> Result<(String, StateCache), Error> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
note: in edition 2024, the requirement `!: FromRedisValue` will fail
   --> apps/indexer-proxy/proxy/src/websocket.rs:312:14
    |
312 |             .query_async(&mut conn)
    |              ^^^^^^^^^^^

warning: `subql-indexer-proxy` (bin "subql-indexer-proxy") generated 2 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.57s
```