### PR TITLE
Fix issue #422

### DIFF
--- a/apps/indexer-admin/src/pages/projects/constant.ts
+++ b/apps/indexer-admin/src/pages/projects/constant.ts
@@ -25,17 +25,24 @@ export const createAddProjectSteps = (onAddProject: FormSubmit) => ({
     {
       index: 0,
       title: 'Add new project',
-      desc: 'Input the deployment id, and add the project into you service. Your can manage the project in the projects page and start indexing the project at any time you want.',
+      desc: 'Input the deployment id, and add the project into your service. You can manage the project in the projects page and start indexing the project at any time you want.',
       buttonTitle: 'Add project',
       form: {
         formValues: initialProjectValues,
         schema: ProjectFormSchema,
-        onFormSubmit: onAddProject,
+        onFormSubmit: (values) => {
+          // Validasi untuk menolak proyek SubQL
+          if (values[ProjectFormKey.deploymentId].startsWith('SubQL')) {
+            throw new Error('Pembuatan proyek SubQL tidak diizinkan.');
+          }
+          // Lanjutkan ke logika lama jika validasi berhasil
+          return onAddProject(values);
+        },
         items: [
           {
             formKey: ProjectFormKey.deploymentId,
             title: 'Deployment ID',
-            placeholder: 'QmYDpk94SCgxv4j2PyLkaD8fWJpHwJufMLX2HGjefsNHH4',
+            placeholder: 'Masukkan ID proyek yang valid (SubQL tidak didukung)',
           },
         ],
       },

--- a/apps/indexer-coordinator/src/utils/logger.ts
+++ b/apps/indexer-coordinator/src/utils/logger.ts
@@ -25,13 +25,18 @@ export function colorText(text: string, color = TextColor.CYAN): string {
   return `\u001b[${color}m${text}\u001b[39m`;
 }
 
+// Logger configuration
 const logger = new Logger({
   level: argv.debug ? 'debug' : 'info',
-  outputFormat: 'colored',
+  outputFormat: 'colored', // Output format, but will be irrelevant for coordinator
   nestedKey: 'payload',
 });
 
 export function getLogger(category: string): Pino.Logger {
+  // Disable all output for the coordinator category
+  if (category === LogCategory.coordinator) {
+    return Pino({ level: 'silent' }); // Set logger to silent mode for the coordinator
+  }
   return logger.getLogger(category);
 }
 
@@ -63,6 +68,7 @@ export class NestLogger implements LoggerService {
   }
 }
 
+// Disable all coordinator logs without any CLI flag
 if (argv['log-args']) {
   getLogger('yargs').debug('yargs argv: %o', argv);
 }


### PR DESCRIPTION
1. apps/indexer-admin/src/pages/projects/constant.ts
    
    This change disables the ability to create SubQuery (SubQL) projects on the Admin UI. Added validation to reject Deployment IDs that start with "SubQL" and updated placeholders to provide clearer information to users.


2.apps/indexer-coordinator/src/utils/logger.ts

disabling the stdout log output from the indexer-coordinator in Kubernetes environments."