### PR TITLE
Support metrics for Polygon Bor (Geth fork)

### DIFF
--- a/apps/indexer-coordinator/src/utils/metrics.ts
+++ b/apps/indexer-coordinator/src/utils/metrics.ts
@@ -74,6 +74,10 @@ export function parseMetrics(metrics: string): MetricsData {
     if (lines[i].startsWith('# TYPE geth_info')) {
       mType = MetricsType.GETH_PROMETHEUS;
     }
+    // geth bor
+    else if (lines[i].startsWith('# TYPE rpc_duration_bor')) {
+      mType = MetricsType.GETH_PROMETHEUS;
+    }
     if (lines[i].startsWith('# TYPE chain_info')) {
       /**
         # TYPE chain_info gauge


### PR DESCRIPTION

Bor metrics path: `/debug/metrics/prometheus`
Bor metrics: [T4FBb.txt](https://github.com/user-attachments/files/18973129/T4FBb.txt)


Added support for Bor metrics by path "rpc_duration_bor"